### PR TITLE
Reduce memory usage and bump EBS CSI driver

### DIFF
--- a/caddy/Caddyfile
+++ b/caddy/Caddyfile
@@ -18,7 +18,7 @@ file_server
 encode gzip
 mwcache {
 	ristretto {
-		num_counters 50000
+		num_counters 30000
 		max_cost 10000
 		buffer_items 64
 	}

--- a/jobs/development/mysql.nomad
+++ b/jobs/development/mysql.nomad
@@ -7,8 +7,11 @@ job "mysql" {
 
       config {
         image             = "mysql/mysql-server:8.0"
-        args              = ["--default-authentication-plugin=mysql_native_password"]
         memory_hard_limit = 1000
+        args = [
+          "--default_authentication_plugin=mysql_native_password",
+          "--max-connections=20"
+        ]
       }
 
       resources {

--- a/jobs/fastcgi.nomad
+++ b/jobs/fastcgi.nomad
@@ -57,7 +57,7 @@ job "fastcgi" {
         destination = "local/www.conf"
         mode        = "file"
 
-        options { checksum = "md5:bf4d0d65b0e696c098213b75cee5d80a" }
+        options { checksum = "md5:fce04b4c5d3191a86a5cdd17c3911dee" }
       }
 
       template {

--- a/jobs/mysql.nomad
+++ b/jobs/mysql.nomad
@@ -27,8 +27,8 @@ job "mysql" {
         image   = "mysql/mysql-server:8.0.23"
         volumes = ["local/custom.cnf:/etc/mysql/conf.d/custom.cnf"]
         args = [
-          "--default-authentication-plugin=mysql_native_password",
-          "--datadir", "/srv/mysql"
+          "--max-connections=20",
+          "--datadir", "/srv/mysql",
         ]
         memory_hard_limit = 800
       }

--- a/jobs/plugin-ebs-controller.nomad
+++ b/jobs/plugin-ebs-controller.nomad
@@ -8,7 +8,7 @@ job "plugin-ebs-controller" {
       driver = "docker"
 
       config {
-        image = "amazon/aws-ebs-csi-driver:v0.10.1"
+        image = "amazon/aws-ebs-csi-driver:v1.0.0"
 
         args = [
           "controller",

--- a/jobs/plugin-ebs-nodes.nomad
+++ b/jobs/plugin-ebs-nodes.nomad
@@ -18,7 +18,7 @@ job "plugin-ebs-nodes" {
       driver = "docker"
 
       config {
-        image = "amazon/aws-ebs-csi-driver:v0.10.1"
+        image = "amazon/aws-ebs-csi-driver:v1.0.0"
 
         args = [
           "node",

--- a/php/www.conf
+++ b/php/www.conf
@@ -1,9 +1,11 @@
+# After editing this file, you should edit checksum in mysql.nomad also.
+# See https://www.nomadproject.io/docs/job-specification/artifact#download-and-verify-checksums for further details
 [www]
 user = www-data
 group = www-data
 listen = 127.0.0.1:9000
 pm = dynamic
-pm.max_children = 20
+pm.max_children = 10
 pm.start_servers = 2
 pm.min_spare_servers = 1
 pm.max_spare_servers = 3


### PR DESCRIPTION
- Bump [aws-ebs-csi-driver](https://github.com/kubernetes-sigs/aws-ebs-csi-driver) to v1
- Reduce memory usages
  - MySQL: Reduce [max connections](https://dev.mysql.com/doc/refman/8.0/en/server-system-variables.html#sysvar_max_connections) from 151 to 20.
  - caddy-mwcache: Reduce counter from 50000 to 30000.
  - PHP-fpm: Reduce [max_children](https://www.php.net/manual/en/install.fpm.configuration.php#pm.max-children) from 20 to 10.

According to [this blog post](https://tech.labelleassiette.com/how-to-reduce-the-memory-usage-of-mysql-61ea7d1a9bd), our maximum memory usage of MySQL is up to 2746.133 MB, this patch reduces it to 495.594 MB.

```sql
> show status like '%used_connection%';
stdClass Object
(
    [Variable_name] => Max_used_connections
    [Value] => 17
)
stdClass Object
(
    [Variable_name] => Max_used_connections_time
    [Value] => 2021-05-04 10:28:30
)
```

Related to https://github.com/femiwiki/femiwiki/issues/249