### PR TITLE
Weekly deploy - 18

### DIFF
--- a/jobs/fastcgi.nomad
+++ b/jobs/fastcgi.nomad
@@ -67,7 +67,7 @@ job "fastcgi" {
       }
 
       config {
-        image = "ghcr.io/femiwiki/mediawiki:2021-04-30T05-37-796b1cff"
+        image = "ghcr.io/femiwiki/mediawiki:2021-05-07T16-04-895338b3"
 
         volumes = [
           "local/opcache-recommended.ini:/usr/local/etc/php/conf.d/opcache-recommended.ini",

--- a/jobs/mysql.nomad
+++ b/jobs/mysql.nomad
@@ -22,7 +22,7 @@ job "mysql" {
         destination = "local/my.cnf"
         mode        = "file"
 
-        options { checksum = "md5:114bd42a9b63ee0560c43ffbf2686ce1" }
+        options { checksum = "md5:cc542eaf6a22c20e99f090f1c5ae0304" }
       }
 
       config {

--- a/mysql/my.cnf
+++ b/mysql/my.cnf
@@ -8,3 +8,5 @@ datadir=/srv/mysql
 max_connections=20
 temptable_max_ram=128M
 temptable_max_mmap=128M
+max_binlog_cache_size=32768
+max_binlog_stmt_cache_size=32768


### PR DESCRIPTION
- Define font-family for `[lang=ja]` (https://github.com/femiwiki/FemiwikiSkin/issues/229)
- Lower [max_binlog_cache_size](https://dev.mysql.com/doc/refman/8.0/en/replication-options-binary-log.html#sysvar_max_binlog_cache_size) and [max_binlog_stmt_cache_size](https://dev.mysql.com/doc/refman/8.0/en/replication-options-binary-log.html#sysvar_max_binlog_stmt_cache_size) of MySQL (https://github.com/femiwiki/nomad/issues/29)