### PR TITLE
Weekly Deploy - 2021-21

### DIFF
--- a/jobs-consul-test/fastcgi.nomad
+++ b/jobs-consul-test/fastcgi.nomad
@@ -63,7 +63,7 @@ job "fastcgi" {
       }
 
       config {
-        image = "ghcr.io/femiwiki/mediawiki:2021-05-28T12-27-34da1d3f"
+        image = "ghcr.io/femiwiki/mediawiki:2021-05-28T14-01-0b1f9738"
         ports = ["fastcgi"]
 
         volumes = [

--- a/jobs-consul-test/fastcgi.nomad
+++ b/jobs-consul-test/fastcgi.nomad
@@ -63,7 +63,7 @@ job "fastcgi" {
       }
 
       config {
-        image = "ghcr.io/femiwiki/mediawiki:2021-05-21T14-05-b627fbec"
+        image = "ghcr.io/femiwiki/mediawiki:2021-05-28T12-27-34da1d3f"
         ports = ["fastcgi"]
 
         volumes = [

--- a/jobs-consul-test/http.nomad
+++ b/jobs-consul-test/http.nomad
@@ -12,7 +12,7 @@ job "http" {
       }
 
       config {
-        image   = "ghcr.io/femiwiki/mediawiki:2021-04-19T12-14-11fd8960"
+        image   = "ghcr.io/femiwiki/mediawiki:2021-05-28T12-27-34da1d3f"
         command = "caddy"
         args    = ["run"]
         volumes = ["local/Caddyfile:/srv/femiwiki.com/Caddyfile"]

--- a/jobs-consul-test/http.nomad
+++ b/jobs-consul-test/http.nomad
@@ -12,7 +12,7 @@ job "http" {
       }
 
       config {
-        image   = "ghcr.io/femiwiki/mediawiki:2021-05-28T12-27-34da1d3f"
+        image   = "ghcr.io/femiwiki/mediawiki:2021-05-28T14-01-0b1f9738"
         command = "caddy"
         args    = ["run"]
         volumes = ["local/Caddyfile:/srv/femiwiki.com/Caddyfile"]

--- a/jobs-consul-test/restbase.nomad
+++ b/jobs-consul-test/restbase.nomad
@@ -6,7 +6,7 @@ job "restbase" {
       driver = "docker"
 
       config {
-        image = "ghcr.io/femiwiki/restbase:2021-04-17T11-25-e5b25017"
+        image = "ghcr.io/femiwiki/restbase:2021-05-25T01-32-1a60cdd5"
 
         mounts = [
           {

--- a/jobs/fastcgi.nomad
+++ b/jobs/fastcgi.nomad
@@ -110,8 +110,8 @@ job "fastcgi" {
         NOMAD_UPSTREAM_ADDR_restbase  = "127.0.0.1:7231"
         NOMAD_UPSTREAM_ADDR_mathoid   = "127.0.0.1:10044"
         MEDIAWIKI_SKIP_INSTALL        = "1"
-        # MEDIAWIKI_SKIP_UPDATE         = "1"
         MEDIAWIKI_SKIP_IMPORT_SITES   = "1"
+        # MEDIAWIKI_SKIP_UPDATE         = "1"
       }
     }
   }

--- a/jobs/fastcgi.nomad
+++ b/jobs/fastcgi.nomad
@@ -69,7 +69,7 @@ job "fastcgi" {
       }
 
       config {
-        image = "ghcr.io/femiwiki/mediawiki:2021-05-21T14-05-b627fbec"
+        image = "ghcr.io/femiwiki/mediawiki:2021-05-28T12-27-34da1d3f"
 
         volumes = [
           "local/opcache-recommended.ini:/usr/local/etc/php/conf.d/opcache-recommended.ini",
@@ -110,7 +110,7 @@ job "fastcgi" {
         NOMAD_UPSTREAM_ADDR_restbase  = "127.0.0.1:7231"
         NOMAD_UPSTREAM_ADDR_mathoid   = "127.0.0.1:10044"
         MEDIAWIKI_SKIP_INSTALL        = "1"
-        MEDIAWIKI_SKIP_UPDATE         = "1"
+        # MEDIAWIKI_SKIP_UPDATE         = "1"
         MEDIAWIKI_SKIP_IMPORT_SITES   = "1"
       }
     }

--- a/jobs/fastcgi.nomad
+++ b/jobs/fastcgi.nomad
@@ -69,7 +69,7 @@ job "fastcgi" {
       }
 
       config {
-        image = "ghcr.io/femiwiki/mediawiki:2021-05-28T12-27-34da1d3f"
+        image = "ghcr.io/femiwiki/mediawiki:2021-05-28T14-01-0b1f9738"
 
         volumes = [
           "local/opcache-recommended.ini:/usr/local/etc/php/conf.d/opcache-recommended.ini",

--- a/jobs/http.nomad
+++ b/jobs/http.nomad
@@ -24,7 +24,7 @@ job "http" {
       }
 
       config {
-        image   = "ghcr.io/femiwiki/mediawiki:2021-05-28T12-27-34da1d3f"
+        image   = "ghcr.io/femiwiki/mediawiki:2021-05-28T14-01-0b1f9738"
         command = "caddy"
         args    = ["run"]
 

--- a/jobs/http.nomad
+++ b/jobs/http.nomad
@@ -24,7 +24,7 @@ job "http" {
       }
 
       config {
-        image   = "ghcr.io/femiwiki/mediawiki:2021-05-20T04-45-4904027b"
+        image   = "ghcr.io/femiwiki/mediawiki:2021-05-28T12-27-34da1d3f"
         command = "caddy"
         args    = ["run"]
 

--- a/jobs/restbase.nomad
+++ b/jobs/restbase.nomad
@@ -6,7 +6,7 @@ job "restbase" {
       driver = "docker"
 
       config {
-        image = "ghcr.io/femiwiki/restbase:2021-04-17T11-25-e5b25017"
+        image = "ghcr.io/femiwiki/restbase:2021-05-25T01-32-1a60cdd5"
 
         mounts = [
           {

--- a/mysql/my.cnf
+++ b/mysql/my.cnf
@@ -5,7 +5,7 @@
 # https://dev.mysql.com/doc/refman/8.0/en/server-system-variables.html#sysvar_default_authentication_plugin
 default_authentication_plugin=mysql_native_password
 datadir=/srv/mysql
-max_connections=20
+max_connections=60
 table_open_cache=300
 performance_schema=OFF
 temptable_max_ram=64M


### PR DESCRIPTION
- Bump MediaWiki to 1.36.0 (https://github.com/femiwiki/docker-mediawiki/issues/512)
- Undeploy the CollaborationKit extension and its dependencies (https://github.com/femiwiki/femiwiki/issues/194)
- Increase max_connections of MySQL from 20 to 50
- DiscordNotifications
  - Fix broken links on file upload (https://github.com/femiwiki/DiscordNotifications/issues/8)
  - Send notifications from Extension:Sanctions (https://github.com/femiwiki/femiwiki/issues/234)
- Bump Composer from 2.0.13 to 2.0.14 (https://github.com/femiwiki/docker-mediawiki/commit/87b59b5a427dec25b3387086f9ad8a58898abad4)
- Bump Caddy from 2.4.0 to 2.4.1 (https://github.com/femiwiki/docker-mediawiki/pull/521)