### PR TITLE
Weekly Deploy - 24

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,7 +59,14 @@ jobs:
       - name: Wait for initializing...
         timeout-minutes: 5
         run: |
+          TIME=0
           until nomad node status > /dev/null; do
+            if [ $TIME -gt 30 ]; then
+              if [ -n "$(pidof nomad)" ]; then sudo kill "$(pidof nomad)"; fi
+              sudo nomad agent -dev-connect -config nomad/development.hcl &>/dev/null &
+              TIME=0
+            fi
+            ((TIME+=1))
             sleep 1; done;
           NODE_ID="$(nomad node status -self | head -1 | awk '{print $3}')"
           until [[ $(curl -s "http://127.0.0.1:4646/v1/node/$NODE_ID") = *"consul.version"* ]]; do

--- a/jobs-consul-test/backupbot.nomad
+++ b/jobs-consul-test/backupbot.nomad
@@ -41,11 +41,9 @@ job "backupbot" {
         }
 
         sidecar_task {
-          config {
-            memory_hard_limit = 300
-          }
           resources {
-            memory = 30
+            memory     = 30
+            memory_max = 300
           }
         }
       }

--- a/jobs-consul-test/development/lb.nomad
+++ b/jobs-consul-test/development/lb.nomad
@@ -33,7 +33,6 @@ job "lb" {
       config {
         image             = "traefik:v2.4.8"
         network_mode      = "host"
-        memory_hard_limit = 500
         ports             = ["http", "api"]
 
         volumes = [
@@ -67,6 +66,7 @@ EOF
 
       resources {
         memory = 128
+        memory_max = 500
       }
     }
   }

--- a/jobs-consul-test/development/mathoid.nomad
+++ b/jobs-consul-test/development/mathoid.nomad
@@ -7,11 +7,11 @@ job "mathoid" {
 
       config {
         image = "ghcr.io/femiwiki/mathoid:latest"
-        memory_hard_limit = 600
       }
 
       resources {
         memory = 150
+        memory_max = 600
       }
 
       env {
@@ -32,11 +32,9 @@ job "mathoid" {
         sidecar_service {}
 
         sidecar_task {
-          config {
-            memory_hard_limit = 500
-          }
           resources {
             memory = 100
+        memory_max = 500
           }
         }
       }

--- a/jobs-consul-test/fastcgi.nomad
+++ b/jobs-consul-test/fastcgi.nomad
@@ -69,7 +69,7 @@ job "fastcgi" {
       }
 
       config {
-        image = "ghcr.io/femiwiki/mediawiki:2021-05-28T22-03-473c97b0"
+        image = "ghcr.io/femiwiki/mediawiki:latest"
         ports = ["fastcgi"]
 
         volumes = [

--- a/jobs-consul-test/fastcgi.nomad
+++ b/jobs-consul-test/fastcgi.nomad
@@ -33,6 +33,12 @@ job "fastcgi" {
       }
 
       artifact {
+        source      = "s3::https://femiwiki-secrets.s3-ap-northeast-1.amazonaws.com/analytics-credentials-file.json"
+        destination = "secrets/analytics-credentials-file.json"
+        mode        = "file"
+      }
+
+      artifact {
         source      = "https://github.com/femiwiki/nomad/raw/main/php/opcache-recommended.ini"
         destination = "local/opcache-recommended.ini"
         mode        = "file"
@@ -68,6 +74,7 @@ job "fastcgi" {
 
         volumes = [
           "secrets/secrets.php:/a/secret.php",
+          "secrets/analytics-credentials-file.json:/a/analytics-credentials-file.json",
           "local/opcache-recommended.ini:/usr/local/etc/php/conf.d/opcache-recommended.ini",
           "local/php.ini:/usr/local/etc/php/php.ini",
           "local/php-fpm.conf:/usr/local/etc/php-fpm.conf",

--- a/jobs-consul-test/fastcgi.nomad
+++ b/jobs-consul-test/fastcgi.nomad
@@ -97,12 +97,11 @@ job "fastcgi" {
             readonly = false
           },
         ]
-
-        memory_hard_limit = 800
       }
 
       resources {
-        memory = 300
+        memory     = 300
+        memory_max = 800
       }
 
       env {
@@ -157,11 +156,9 @@ job "fastcgi" {
         }
 
         sidecar_task {
-          config {
-            memory_hard_limit = 300
-          }
           resources {
-            memory = 30
+            memory     = 30
+            memory_max = 300
           }
         }
       }

--- a/jobs-consul-test/http.nomad
+++ b/jobs-consul-test/http.nomad
@@ -34,12 +34,11 @@ job "http" {
         ulimit {
           nofile = "20000:40000"
         }
-
-        memory_hard_limit = 400
       }
 
       resources {
-        memory = 100
+        memory     = 100
+        memory_max = 400
       }
 
       env {
@@ -90,11 +89,9 @@ job "http" {
         }
 
         sidecar_task {
-          config {
-            memory_hard_limit = 500
-          }
           resources {
-            memory = 300
+            memory     = 300
+            memory_max = 500
           }
         }
       }

--- a/jobs-consul-test/http.nomad
+++ b/jobs-consul-test/http.nomad
@@ -12,7 +12,7 @@ job "http" {
       }
 
       config {
-        image   = "ghcr.io/femiwiki/mediawiki:2021-05-28T14-01-0b1f9738"
+        image   = "ghcr.io/femiwiki/mediawiki:latest"
         command = "caddy"
         args    = ["run"]
         volumes = ["local/Caddyfile:/srv/femiwiki.com/Caddyfile"]

--- a/jobs-consul-test/lb.nomad
+++ b/jobs-consul-test/lb.nomad
@@ -56,12 +56,11 @@ job "lb" {
             readonly = false
           },
         ]
-
-        memory_hard_limit = 500
       }
 
       resources {
-        memory = 128
+        memory     = 128
+        memory_max = 500
       }
     }
   }

--- a/jobs-consul-test/mathoid.nomad
+++ b/jobs-consul-test/mathoid.nomad
@@ -31,11 +31,9 @@ job "mathoid" {
         sidecar_service {}
 
         sidecar_task {
-          config {
-            memory_hard_limit = 500
-          }
           resources {
-            memory = 300
+            memory     = 300
+            memory_max = 500
           }
         }
       }

--- a/jobs-consul-test/memcached.nomad
+++ b/jobs-consul-test/memcached.nomad
@@ -26,11 +26,9 @@ job "memcached" {
         sidecar_service {}
 
         sidecar_task {
-          config {
-            memory_hard_limit = 300
-          }
           resources {
-            memory = 30
+            memory     = 30
+            memory_max = 300
           }
         }
       }

--- a/jobs-consul-test/mysql.nomad
+++ b/jobs-consul-test/mysql.nomad
@@ -26,13 +26,13 @@ job "mysql" {
       }
 
       config {
-        image             = "mysql/mysql-server:8.0.25"
-        volumes           = ["local/my.cnf:/etc/mysql/my.cnf"]
-        memory_hard_limit = 800
+        image   = "mysql/mysql-server:8.0.25"
+        volumes = ["local/my.cnf:/etc/mysql/my.cnf"]
       }
 
       resources {
-        memory = 300
+        memory     = 300
+        memory_max = 800
       }
 
       env {
@@ -52,11 +52,9 @@ job "mysql" {
         sidecar_service {}
 
         sidecar_task {
-          config {
-            memory_hard_limit = 300
-          }
           resources {
-            memory = 30
+            memory     = 30
+            memory_max = 300
           }
         }
       }

--- a/jobs-consul-test/restbase.nomad
+++ b/jobs-consul-test/restbase.nomad
@@ -16,12 +16,11 @@ job "restbase" {
             readonly = false
           }
         ]
-
-        memory_hard_limit = 400
       }
 
       resources {
-        memory = 100
+        memory     = 100
+        memory_max = 400
       }
 
       env {
@@ -58,11 +57,9 @@ job "restbase" {
         }
 
         sidecar_task {
-          config {
-            memory_hard_limit = 500
-          }
           resources {
-            memory = 300
+            memory     = 300
+            memory_max = 500
           }
         }
       }

--- a/jobs/development/fastcgi.nomad
+++ b/jobs/development/fastcgi.nomad
@@ -39,7 +39,6 @@ job "fastcgi" {
       config {
         image             = "ghcr.io/femiwiki/mediawiki:latest"
         network_mode      = "host"
-        memory_hard_limit = 600
 
         volumes = [
           "secrets/secrets.php:/a/secret.php",
@@ -70,6 +69,7 @@ job "fastcgi" {
 
       resources {
         memory = 100
+        memory_max = 600
       }
     }
   }

--- a/jobs/development/http.nomad
+++ b/jobs/development/http.nomad
@@ -86,11 +86,11 @@ job "http" {
         ]
 
         network_mode      = "host"
-        memory_hard_limit = 400
       }
 
       resources {
         memory = 80
+        memory_max = 400
       }
     }
   }

--- a/jobs/development/mathoid.nomad
+++ b/jobs/development/mathoid.nomad
@@ -7,11 +7,11 @@ job "mathoid" {
 
       config {
         image = "ghcr.io/femiwiki/mathoid:latest"
-        memory_hard_limit = 600
       }
 
       resources {
         memory = 150
+        memory_max = 600
       }
 
       env {

--- a/jobs/development/memcached.nomad
+++ b/jobs/development/memcached.nomad
@@ -7,11 +7,11 @@ job "memcached" {
 
       config {
         image             = "memcached:1-alpine"
-        memory_hard_limit = 240
       }
 
       resources {
         memory = 60
+        memory_max = 240
       }
     }
 

--- a/jobs/development/mysql.nomad
+++ b/jobs/development/mysql.nomad
@@ -25,7 +25,6 @@ EOF
 
       config {
         image             = "mysql/mysql-server:8.0"
-        memory_hard_limit = 1000
         volumes           = ["local/my.cnf:/etc/mysql/my.cnf"]
 
         mounts = [
@@ -40,6 +39,7 @@ EOF
 
       resources {
         memory = 500
+        memory_max = 1000
       }
 
       env {

--- a/jobs/development/restbase.nomad
+++ b/jobs/development/restbase.nomad
@@ -8,11 +8,11 @@ job "restbase" {
       config {
         image             = "ghcr.io/femiwiki/restbase:latest"
         network_mode      = "host"
-        memory_hard_limit = 400
       }
 
       resources {
         memory = 100
+        memory_max = 400
       }
 
       env {

--- a/jobs/fastcgi.nomad
+++ b/jobs/fastcgi.nomad
@@ -33,6 +33,12 @@ job "fastcgi" {
       }
 
       artifact {
+        source      = "s3::https://femiwiki-secrets.s3-ap-northeast-1.amazonaws.com/analytics-credentials-file.json"
+        destination = "secrets/analytics-credentials-file.json"
+        mode        = "file"
+      }
+
+      artifact {
         source      = "https://github.com/femiwiki/nomad/raw/main/php/opcache-recommended.ini"
         destination = "local/opcache-recommended.ini"
         mode        = "file"
@@ -77,6 +83,7 @@ job "fastcgi" {
           "local/php-fpm.conf:/usr/local/etc/php-fpm.conf",
           "local/www.conf:/usr/local/etc/php-fpm.d/www.conf",
           "secrets/secrets.php:/a/secret.php",
+          "secrets/analytics-credentials-file.json:/a/analytics-credentials-file.json",
           # Overwrite the default Hotfix.php provided by femiwiki/mediawiki
           "local/Hotfix.php:/a/Hotfix.php",
         ]

--- a/jobs/fastcgi.nomad
+++ b/jobs/fastcgi.nomad
@@ -103,12 +103,12 @@ job "fastcgi" {
           }
         ]
 
-        network_mode      = "host"
-        memory_hard_limit = 800
+        network_mode = "host"
       }
 
       resources {
-        memory = 400
+        memory     = 400
+        memory_max = 800
       }
 
       env {

--- a/jobs/fastcgi.nomad
+++ b/jobs/fastcgi.nomad
@@ -139,14 +139,18 @@ variable "hotfix" {
   type    = string
   default = <<EOF
 <?php
-// Use this file for hotfixes
+/**
+ * Use this file for hotfixes
+ *
+ * @file
+ */
 
 // Maintenance
-//// 점검이 끝나면 아래 라인 주석처리한 뒤, 아래 문서 내용을 비우면 됨
-//// https://femiwiki.com/w/%EB%AF%B8%EB%94%94%EC%96%B4%EC%9C%84%ED%82%A4:Sitenotice
+// 점검이 끝나면 아래 라인 주석처리한 뒤, 아래 문서 내용을 비우면 됨
+// https://femiwiki.com/w/%EB%AF%B8%EB%94%94%EC%96%B4%EC%9C%84%ED%82%A4:Sitenotice
 // $wgReadOnly = '데이터베이스 업그레이드 작업이 진행 중입니다. 작업이 진행되는 동안 사이트 이용이 제한됩니다.';
 
-//// 업로드를 막고싶을때엔 아래 라인 주석 해제하면 됨
+// 업로드를 막고싶을때엔 아래 라인 주석 해제하면 됨
 // $wgEnableUploads = false;
 EOF
 }

--- a/jobs/fastcgi.nomad
+++ b/jobs/fastcgi.nomad
@@ -75,7 +75,7 @@ job "fastcgi" {
       }
 
       config {
-        image = "ghcr.io/femiwiki/mediawiki:2021-06-11T14-08-16638bc2"
+        image = "ghcr.io/femiwiki/mediawiki:2021-06-18T04-57-20822934"
 
         volumes = [
           "local/opcache-recommended.ini:/usr/local/etc/php/conf.d/opcache-recommended.ini",
@@ -118,7 +118,7 @@ job "fastcgi" {
         NOMAD_UPSTREAM_ADDR_mathoid   = "127.0.0.1:10044"
         MEDIAWIKI_SKIP_INSTALL        = "1"
         MEDIAWIKI_SKIP_IMPORT_SITES   = "1"
-        MEDIAWIKI_SKIP_UPDATE         = "1"
+        # MEDIAWIKI_SKIP_UPDATE         = "1"
       }
     }
   }

--- a/jobs/http.nomad
+++ b/jobs/http.nomad
@@ -50,11 +50,11 @@ job "http" {
         ulimit {
           nofile = "20000:40000"
         }
-        memory_hard_limit = 400
       }
 
       resources {
-        memory = 100
+        memory     = 100
+        memory_max = 400
       }
 
       env {

--- a/jobs/http.nomad
+++ b/jobs/http.nomad
@@ -26,7 +26,7 @@ job "http" {
       }
 
       config {
-        image   = "ghcr.io/femiwiki/mediawiki:2021-06-11T12-34-869d941b"
+        image   = "ghcr.io/femiwiki/mediawiki:2021-06-18T04-57-20822934"
         command = "caddy"
         args    = ["run"]
 

--- a/jobs/mysql.nomad
+++ b/jobs/mysql.nomad
@@ -28,13 +28,13 @@ job "mysql" {
       }
 
       config {
-        image             = "mysql/mysql-server:8.0.25"
-        volumes           = ["local/my.cnf:/etc/mysql/my.cnf"]
-        memory_hard_limit = 800
+        image   = "mysql/mysql-server:8.0.25"
+        volumes = ["local/my.cnf:/etc/mysql/my.cnf"]
       }
 
       resources {
-        memory = 400
+        memory     = 400
+        memory_max = 800
       }
 
       env {

--- a/jobs/restbase.nomad
+++ b/jobs/restbase.nomad
@@ -17,12 +17,12 @@ job "restbase" {
           }
         ]
 
-        network_mode      = "host"
-        memory_hard_limit = 400
+        network_mode = "host"
       }
 
       resources {
-        memory = 100
+        memory     = 100
+        memory_max = 400
       }
 
       env {


### PR DESCRIPTION
- Installs extensions.
  - GrowthExperiments (Closes https://github.com/femiwiki/docker-mediawiki/issues/307)
  - PageViewInfo (Closes https://github.com/femiwiki/femiwiki/issues/115)
  - EventLogging (Closes https://github.com/femiwiki/docker-mediawiki/issues/542)
- Removes 'restricted-sysop' user right group. (Closes https://github.com/femiwiki/femiwiki/issues/273)
- Shows links on a page as RelatedArticles. (Closes https://github.com/femiwiki/femiwiki/issues/269)
- Revokes importupload from sysop.
- Removes unwanted text-decoration of Echo notifications.(https://github.com/femiwiki/FemiwikiSkin/issues/243)
- Adds more cases for resizing large images. (https://github.com/femiwiki/FemiwikiSkin/issues/248)
- Removes padding of `.mwhighlight > pre`. (https://github.com/femiwiki/FemiwikiSkin/issues/245)
- Makes postEdit notification centered evenly. (https://github.com/femiwiki/FemiwikiSkin/issues/45)
- Fixes blue link for ULS in Special:Preferences. (https://github.com/femiwiki/FemiwikiSkin/issues/244)
- Fixes blue link to description page in media settings. (https://github.com/femiwiki/FemiwikiSkin/issues/247)
- Restores 'twitter:card' meta tag and add more tags. (Closes https://github.com/femiwiki/docker-mediawiki/issues/549)
- Uses the default value of $wgResourceLoaderMaxage. (Closes https://github.com/femiwiki/docker-mediawiki/issues/546)
- Undeploys the OpenGraphMeta extension. (https://github.com/femiwiki/docker-mediawiki/issues/551)
- Fixes Wikidata Bridge (Closes https://github.com/femiwiki/docker-mediawiki/issues/324)
- Replaces memory_hard_limit with memory_max. (https://github.com/femiwiki/nomad/issues/41)
- Improves font-family and hyphens per languages. (https://github.com/femiwiki/femiwiki/issues/274)

TODO After merging:

- [ ] Edit https://femiwiki.com/w/MediaWiki:Notification-header-welcome