### PR TITLE
Enable memory oversubscription on bootstrap

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,7 +61,8 @@ jobs:
         run: |
           TIME=0
           until nomad node status > /dev/null; do
-            if [ $TIME -gt 30 ]; then
+            if [ $TIME -gt 60 ]; then
+              echo 'Nomad is not booted after 60 seconds, kill...'
               if [ -n "$(pidof nomad)" ]; then sudo kill "$(pidof nomad)"; fi
               sudo nomad agent -dev-connect -config nomad/development.hcl &>/dev/null &
               TIME=0

--- a/nomad/consul-test.hcl
+++ b/nomad/consul-test.hcl
@@ -9,6 +9,11 @@ acl {
 server {
   enabled          = true
   bootstrap_expect = 2
+
+  default_scheduler_config {
+    # Memory oversubscription is opt-in in Nomad 1.1
+    memory_oversubscription_enabled = true
+  }
 }
 
 # We also use the server as a client.

--- a/nomad/development.hcl
+++ b/nomad/development.hcl
@@ -1,3 +1,10 @@
+server {
+  default_scheduler_config {
+    # Memory oversubscription is opt-in in Nomad 1.1
+    memory_oversubscription_enabled = true
+  }
+}
+
 plugin "docker" {
   config {
     volumes {

--- a/nomad/production.hcl
+++ b/nomad/production.hcl
@@ -9,6 +9,11 @@ server {
   enabled = true
   # A value of 1 does not provide any fault tolerance and is not recommended for production use cases.
   bootstrap_expect = 1
+
+  default_scheduler_config {
+    # Memory oversubscription is opt-in in Nomad 1.1
+    memory_oversubscription_enabled = true
+  }
 }
 
 client {


### PR DESCRIPTION
Explicitly enables memory oversubscription which is opt-in currently. (Nomad 1.1)

Reference: https://www.nomadproject.io/docs/configuration/server#configuring-scheduler-config

Closes #41