### PR TITLE
Weekly Deployment - 25

### DIFF
--- a/jobs/fastcgi.nomad
+++ b/jobs/fastcgi.nomad
@@ -75,7 +75,7 @@ job "fastcgi" {
       }
 
       config {
-        image = "ghcr.io/femiwiki/mediawiki:2021-06-20T13-00-8a75501d"
+        image = "ghcr.io/femiwiki/mediawiki:2021-06-25T02-02-4bcaa838"
 
         volumes = [
           "local/opcache-recommended.ini:/usr/local/etc/php/conf.d/opcache-recommended.ini",

--- a/mysql/my.cnf
+++ b/mysql/my.cnf
@@ -14,3 +14,4 @@ max_binlog_cache_size=32M
 max_binlog_stmt_cache_size=32M
 myisam_mmap_size=64M
 parser_max_mem_size=64M
+tmp_table_size=8M # Defaults to 16M


### PR DESCRIPTION
- Deploys PageViewInfoGA
- mysql: Sets [tmp_table_size](https://dev.mysql.com/doc/refman/8.0/en/server-system-variables.html#sysvar_tmp_table_size) to 8M (https://github.com/femiwiki/nomad/issues/29)
- FemiwikiSkin
  - https://github.com/femiwiki/FemiwikiSkin/issues/257
  - https://github.com/femiwiki/FemiwikiSkin/issues/258
  - https://github.com/femiwiki/FemiwikiSkin/issues/263
  - https://github.com/femiwiki/FemiwikiSkin/issues/266
- UnifiedExtensionForFemiwiki
  - https://github.com/femiwiki/UnifiedExtensionForFemiwiki/issues/1
  - https://github.com/femiwiki/UnifiedExtensionForFemiwiki/issues/42

### TODO

#### before deployment

- [ ] Bump Nomad from 1.1.1 to 1.1.2
- https://github.com/femiwiki/femiwiki/issues/280

#### after deployment

- [ ] Remove `$wgGoogleAnalyticsTrackingID` from secrets.php. https://github.com/femiwiki/docker-mediawiki/commit/6b99e8f37ba0f21e7a16e4d8a8f3760cf13d8530#diff-b630f9a3f47e24ebda029c4874edc5b5d2b59b3da3a34774c6776f627ecb79a3L22-L24
- [ ] Revert https://github.com/femiwiki/remote-gadgets/commit/8ef76596af6afb690050f2eaec54a493acdd8ba1