### PR TITLE
Weekly Deployment - 30

### DIFF
--- a/jobs/fastcgi.nomad
+++ b/jobs/fastcgi.nomad
@@ -75,7 +75,7 @@ job "fastcgi" {
       }
 
       config {
-        image = "ghcr.io/femiwiki/mediawiki:2021-07-24t06-15-e9b07ff8"
+        image = "ghcr.io/femiwiki/mediawiki:2021-07-31T01-54-34662f37"
 
         volumes = [
           "local/opcache-recommended.ini:/usr/local/etc/php/conf.d/opcache-recommended.ini",

--- a/jobs/http.nomad
+++ b/jobs/http.nomad
@@ -32,7 +32,7 @@ job "http" {
       }
 
       config {
-        image   = "ghcr.io/femiwiki/mediawiki:2021-07-24t06-15-e9b07ff8"
+        image   = "ghcr.io/femiwiki/mediawiki:2021-07-31T01-54-34662f37"
         command = "caddy"
         args    = ["run"]
 

--- a/jobs/plugin-ebs-controller.nomad
+++ b/jobs/plugin-ebs-controller.nomad
@@ -8,7 +8,7 @@ job "plugin-ebs-controller" {
       driver = "docker"
 
       config {
-        image = "amazon/aws-ebs-csi-driver:v1.1.3"
+        image = "amazon/aws-ebs-csi-driver:v1.2.0"
 
         args = [
           "controller",

--- a/jobs/plugin-ebs-nodes.nomad
+++ b/jobs/plugin-ebs-nodes.nomad
@@ -18,7 +18,7 @@ job "plugin-ebs-nodes" {
       driver = "docker"
 
       config {
-        image = "amazon/aws-ebs-csi-driver:v1.1.3"
+        image = "amazon/aws-ebs-csi-driver:v1.2.0"
 
         args = [
           "node",


### PR DESCRIPTION
- Bumps aws-ebs-csi-driver to 1.2.0
- Fixes https://github.com/femiwiki/FemiwikiSkin/issues/290
- Makes HelpPanel and Homepage are set when after reset if configured for new users.
- Doubles the number of jobs runs per minute. (https://github.com/femiwiki/docker-mediawiki/commit/167a7f0807ef3f75bb30b900f2b1466d2ed54fdb)
- Closes https://github.com/femiwiki/docker-mediawiki/issues/548
- Closes https://github.com/femiwiki/femiwiki/issues/158
- https://github.com/femiwiki/FemiwikiSkin/pull/288
- Uses the fork of PageImages to use a fallback image of og:image.


### pre-merge

- [x] The checksums are verified.

### pre-apply

- [x] Bump Nomad to 1.1.3

### post-apply

- [ ] https://github.com/femiwiki/infra/issues/114