### PR TITLE
Weekly Deployment - 43

### DIFF
--- a/jobs/backupbot.nomad
+++ b/jobs/backupbot.nomad
@@ -12,7 +12,7 @@ job "backupbot" {
       }
 
       config {
-        image        = "ghcr.io/femiwiki/backupbot:2021-05-13T12-35-60faade0"
+        image        = "ghcr.io/femiwiki/backupbot:2021-10-22T20-01-6df8168f"
         volumes      = ["secrets/secrets.php:/a/secrets.php"]
         network_mode = "host"
       }

--- a/jobs/fastcgi.nomad
+++ b/jobs/fastcgi.nomad
@@ -75,7 +75,7 @@ job "fastcgi" {
       }
 
       config {
-        image = "ghcr.io/femiwiki/mediawiki:2021-10-30T02-27-f5d47f7c"
+        image = "ghcr.io/femiwiki/mediawiki:2021-10-30T11-28-94d505da"
 
         volumes = [
           "local/opcache-recommended.ini:/usr/local/etc/php/conf.d/opcache-recommended.ini",

--- a/jobs/fastcgi.nomad
+++ b/jobs/fastcgi.nomad
@@ -75,7 +75,7 @@ job "fastcgi" {
       }
 
       config {
-        image = "ghcr.io/femiwiki/mediawiki:2021-10-09T15-04-50ad9a68"
+        image = "ghcr.io/femiwiki/mediawiki:2021-10-30T02-27-f5d47f7c"
 
         volumes = [
           "local/opcache-recommended.ini:/usr/local/etc/php/conf.d/opcache-recommended.ini",

--- a/jobs/memcached.nomad
+++ b/jobs/memcached.nomad
@@ -6,7 +6,7 @@ job "memcached" {
       driver = "docker"
 
       config {
-        image = "memcached:1.6.10-alpine"
+        image = "memcached:1.6.12-alpine"
       }
 
       resources {

--- a/jobs/mysql.nomad
+++ b/jobs/mysql.nomad
@@ -28,7 +28,7 @@ job "mysql" {
       }
 
       config {
-        image   = "mysql/mysql-server:8.0.26"
+        image   = "mysql/mysql-server:8.0.27"
         volumes = ["local/my.cnf:/etc/mysql/my.cnf"]
       }
 

--- a/jobs/plugin-ebs-controller.nomad
+++ b/jobs/plugin-ebs-controller.nomad
@@ -8,7 +8,7 @@ job "plugin-ebs-controller" {
       driver = "docker"
 
       config {
-        image = "amazon/aws-ebs-csi-driver:v1.2.1"
+        image = "amazon/aws-ebs-csi-driver:v1.4.0"
 
         args = [
           "controller",

--- a/jobs/plugin-ebs-nodes.nomad
+++ b/jobs/plugin-ebs-nodes.nomad
@@ -18,7 +18,7 @@ job "plugin-ebs-nodes" {
       driver = "docker"
 
       config {
-        image = "amazon/aws-ebs-csi-driver:v1.2.1"
+        image = "amazon/aws-ebs-csi-driver:v1.4.0"
 
         args = [
           "node",


### PR DESCRIPTION
- [x] nomad: Bumps mysql/mysql-server from 8.0.26 to 8.0.27
- [x] backupbot: Bumps mysql/mysql-server from 8.0.26 to 8.0.27
- [x] Bumps amazon/aws-ebs-csi-driver from 1.2.1 to 1.4.0
- [x] Bumps Memcached from 1.6.10 to 1.6.12

### pre-merge

- [x] The checksums are verified.

### pre-deploy

- [x] Bump nomad from 1.1.3 to 1.1.6