### PR TITLE
Update csi-nasty-hack

### DIFF
--- a/systemd/csi-nasty-hack
+++ b/systemd/csi-nasty-hack
@@ -34,4 +34,4 @@ detach_volume()
 }
 
 detach_volume mysql mysql
-detach_volume fastcgi caddycerts
+detach_volume http caddycerts


### PR DESCRIPTION
The `caddycerts` volume is for the `http` job, not the `fastcgi` job.

### pre-merge

- [x] The checksums are verified.
- [x] The `MEDIAWIKI_SKIP_UPDATE` environment variable is set correctly.
