### PR TITLE
2022-04 Deployment

### DIFF
--- a/jobs/fastcgi.nomad
+++ b/jobs/fastcgi.nomad
@@ -75,7 +75,7 @@ job "fastcgi" {
       }
 
       config {
-        image = "ghcr.io/femiwiki/mediawiki:2022-04-01T04-16-230ab914"
+        image = "ghcr.io/femiwiki/mediawiki:2022-04-20t22-35-17a4db24"
 
         volumes = [
           "local/opcache-recommended.ini:/usr/local/etc/php/conf.d/opcache-recommended.ini",
@@ -144,11 +144,6 @@ variable "hotfix" {
  *
  * @file
  */
-
-$wgUnifiedExtensionForFemiwikiSoftDefaultOptions = [];
-$wgDefaultUserOptions['visualeditor-newwikitext'] = 1;
-$wgDefaultUserOptions['visualeditor-tabs'] = 'prefer-ve';
-$wgDefaultUserOptions['FemiwikiUseLargerElements'] = 1;
 
 // Maintenance
 // 점검이 끝나면 아래 라인 주석처리한 뒤, 아래 문서 내용을 비우면 됨

--- a/jobs/memcached.nomad
+++ b/jobs/memcached.nomad
@@ -6,7 +6,7 @@ job "memcached" {
       driver = "docker"
 
       config {
-        image = "memcached:1.6.13-alpine"
+        image = "memcached:1.6.15-alpine"
       }
 
       resources {

--- a/jobs/mysql.nomad
+++ b/jobs/mysql.nomad
@@ -28,7 +28,7 @@ job "mysql" {
       }
 
       config {
-        image   = "mysql/mysql-server:8.0.27"
+        image   = "mysql/mysql-server:8.0.28-1.2.7-server"
         volumes = ["local/my.cnf:/etc/mysql/my.cnf"]
       }
 

--- a/jobs/plugin-ebs-controller.nomad
+++ b/jobs/plugin-ebs-controller.nomad
@@ -8,7 +8,7 @@ job "plugin-ebs-controller" {
       driver = "docker"
 
       config {
-        image = "amazon/aws-ebs-csi-driver:v1.5.1"
+        image = "amazon/aws-ebs-csi-driver:v1.5.3"
 
         args = [
           "controller",

--- a/jobs/plugin-ebs-nodes.nomad
+++ b/jobs/plugin-ebs-nodes.nomad
@@ -18,7 +18,7 @@ job "plugin-ebs-nodes" {
       driver = "docker"
 
       config {
-        image = "amazon/aws-ebs-csi-driver:v1.5.1"
+        image = "amazon/aws-ebs-csi-driver:v1.5.3"
 
         args = [
           "node",


### PR DESCRIPTION
- Bump mediawiki docker image ([diff](https://github.com/femiwiki/docker-mediawiki/compare/230ab914..17a4db24))
  - https://github.com/femiwiki/docker-mediawiki/pull/691
  - FemiwikiSkin v1.10.10 to v2.0.0 ([diff](https://github.com/femiwiki/FemiwikiSkin/compare/v1.10.10..v2.0.0))
    - https://github.com/femiwiki/FemiwikiSkin/pull/514
- Bump Memcached from 1.6.13 to 1.6.15
- Bump MySQL from 8.0.27 to 8.0.28
- amazon/aws-ebs-csi-driver from v1.5.1 to v1.5.3

### pre-merge

- [ ] The checksums are verified.
- [ ] The `MEDIAWIKI_SKIP_UPDATE` environment variable is set correctly.

### Notes
- [Changes in MySQL 8.0.28](https://dev.mysql.com/doc/relnotes/mysql/8.0/en/news-8-0-28.html)