### PR TITLE
Deployment 2022-07

### DIFF
--- a/jobs/fastcgi.nomad
+++ b/jobs/fastcgi.nomad
@@ -75,7 +75,7 @@ job "fastcgi" {
       }
 
       config {
-        image = "ghcr.io/femiwiki/mediawiki:2022-05-01T03-27-4111ed93"
+        image = "ghcr.io/femiwiki/mediawiki:2022-07-09T03-28-93abbd52"
 
         volumes = [
           "local/opcache-recommended.ini:/usr/local/etc/php/conf.d/opcache-recommended.ini",
@@ -117,7 +117,7 @@ job "fastcgi" {
         NOMAD_UPSTREAM_ADDR_restbase  = "127.0.0.1:7231"
         MEDIAWIKI_SKIP_INSTALL        = "1"
         MEDIAWIKI_SKIP_IMPORT_SITES   = "1"
-        MEDIAWIKI_SKIP_UPDATE         = "1"
+        # MEDIAWIKI_SKIP_UPDATE         = "1"
       }
     }
   }

--- a/jobs/fastcgi.nomad
+++ b/jobs/fastcgi.nomad
@@ -75,7 +75,7 @@ job "fastcgi" {
       }
 
       config {
-        image = "ghcr.io/femiwiki/mediawiki:2022-07-09T03-28-93abbd52"
+        image = "ghcr.io/femiwiki/mediawiki:2022-07-09t14-09-0dc5ae58"
 
         volumes = [
           "local/opcache-recommended.ini:/usr/local/etc/php/conf.d/opcache-recommended.ini",

--- a/jobs/http.nomad
+++ b/jobs/http.nomad
@@ -32,7 +32,7 @@ job "http" {
       }
 
       config {
-        image   = "ghcr.io/femiwiki/mediawiki:2022-07-09T03-28-93abbd52"
+        image   = "ghcr.io/femiwiki/mediawiki:2022-07-09t14-09-0dc5ae58"
         command = "caddy"
         args    = ["run"]
 

--- a/jobs/http.nomad
+++ b/jobs/http.nomad
@@ -32,7 +32,7 @@ job "http" {
       }
 
       config {
-        image   = "ghcr.io/femiwiki/mediawiki:2021-11-19T07-36-b8b158b1"
+        image   = "ghcr.io/femiwiki/mediawiki:2022-07-09T03-28-93abbd52"
         command = "caddy"
         args    = ["run"]
 


### PR DESCRIPTION
Bumps MediaWiki to 1.38.2.

### pre-merge

- [x] The checksums are verified.
- [x] The `MEDIAWIKI_SKIP_UPDATE` environment variable is set correctly.
