### PR TITLE
Update bump-mediawiki.yml

### DIFF
--- a/.github/workflows/bump-mediawiki.yml
+++ b/.github/workflows/bump-mediawiki.yml
@@ -11,6 +11,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v3
+      - uses: actions/setup-go@v3
 
       - uses: actions/github-script@v6
         id: vars


### PR DESCRIPTION
### pre-merge

- [ ] The checksums are verified.
- [ ] The `MEDIAWIKI_SKIP_UPDATE` environment variable is set correctly.
