### PR TITLE
Revert "Deployment 2023-02-1 (#128)"

### DIFF
--- a/jobs/fastcgi.nomad
+++ b/jobs/fastcgi.nomad
@@ -75,7 +75,7 @@ job "fastcgi" {
       }
 
       config {
-        image = "ghcr.io/femiwiki/mediawiki:2023-02-11T16-51-a0a1f9ad"
+        image = "ghcr.io/femiwiki/mediawiki:2023-01-23t14-54-fe54fe0d"
 
         volumes = [
           "local/opcache-recommended.ini:/usr/local/etc/php/conf.d/opcache-recommended.ini",


### PR DESCRIPTION
This reverts commit 47163fb307f968c141b163370a9ab509911c90dc.

### pre-merge

- [ ] The checksums are verified.
- [ ] The `MEDIAWIKI_SKIP_UPDATE` environment variable is set correctly.
