### PR TITLE
Revert bumping mediawiki image

### DIFF
--- a/jobs/fastcgi.nomad
+++ b/jobs/fastcgi.nomad
@@ -75,7 +75,7 @@ job "fastcgi" {
       }
 
       config {
-        image = "ghcr.io/femiwiki/mediawiki:2023-08-08T05-42-5829bae5"
+        image = "ghcr.io/femiwiki/mediawiki:2023-05-30T13-41-78302ac8"
 
         volumes = [
           "local/opcache-recommended.ini:/usr/local/etc/php/conf.d/opcache-recommended.ini",


### PR DESCRIPTION
### pre-merge

- [ ] The checksums are verified.
- [ ] The `MEDIAWIKI_SKIP_UPDATE` environment variable is set correctly.
