### PR TITLE
Hotfix for Monolog

### DIFF
--- a/jobs/fastcgi.nomad
+++ b/jobs/fastcgi.nomad
@@ -142,6 +142,33 @@ variable "hotfix" {
  *
  * @file
  */
+
+$wgMWLoggerDefaultSpi = [
+	'class' => '\\MediaWiki\\Logger\\MonologSpi',
+	'args' => [ [
+		'loggers' => [
+			'@default' => [
+				'processors' => [ 'wiki', 'psr' ],
+				'handlers' => [ 'stream' ]
+			],
+		],
+		'processors' => [
+			'wiki' => [ 'class' => '\\MediaWiki\\Logger\\Monolog\\WikiProcessor' ],
+			'psr' => [ 'class' => '\\Monolog\\Processor\\PsrLogMessageProcessor' ],
+		],
+		'handlers' => [
+			'stream' => [
+				'class' => '\\Monolog\\Handler\\StreamHandler',
+				'args' => [ 'php://stdout' ],
+				'formatter' => 'json'
+			],
+		],
+		'formatters' => [
+			'json' => [ 'class' => '\\Monolog\\Formatter\\JsonFormatter' ],
+		],
+	] ],
+];
+
 // Maintenance
 // 점검이 끝나면 아래 라인 주석처리한 뒤, 아래 문서 내용을 비우면 됨
 // https://femiwiki.com/w/%EB%AF%B8%EB%94%94%EC%96%B4%EC%9C%84%ED%82%A4:Sitenotice


### PR DESCRIPTION
Not urgent, just for skipping the image building process.

https://github.com/femiwiki/femiwiki/issues/347

### pre-merge

- [ ] The checksums are verified.
- [ ] The `MEDIAWIKI_SKIP_UPDATE` environment variable is set correctly.
