### PR TITLE
Workaround for cpu total

### DIFF
--- a/nomad/production.hcl
+++ b/nomad/production.hcl
@@ -18,6 +18,8 @@ server {
 
 client {
   enabled = true
+  # https://github.com/hashicorp/nomad/issues/18871#issuecomment-1781207268
+  cpu_total_compute = 9000
 }
 
 plugin "docker" {


### PR DESCRIPTION
### pre-merge

- [ ] The checksums are verified.
- [ ] The `MEDIAWIKI_SKIP_UPDATE` environment variable is set correctly.
