### PR TITLE
Update fastcgi.nomad

### DIFF
--- a/jobs/fastcgi.nomad
+++ b/jobs/fastcgi.nomad
@@ -143,10 +143,8 @@ variable "hotfix" {
  * @file
  */
 
+$wgUnifiedExtensionForFemiwikiBlockByEmail = false;
 $wgMWLoggerDefaultSpi = [ 'class' => 'MediaWiki\\Logger\\LegacySpi' ]; # default
-$wgLogSpamBlacklistHits = true;
-$wgGroupPermissions['user']['spamblacklistlog'] = false;
-$wgGroupPermissions['sysop']['spamblacklistlog'] = true;
 
 // Maintenance
 // 점검이 끝나면 아래 라인 주석처리한 뒤, 아래 문서 내용을 비우면 됨


### PR DESCRIPTION
1. whitelist와 권한 체크 빠져있어 사용 어려워 비활성화
2. 이메일은 어차피 로그가 안 남아서 제거

### pre-merge

- [ ] The checksums are verified.
- [ ] The `MEDIAWIKI_SKIP_UPDATE` environment variable is set correctly.
