### PR TITLE
Do not reuse autoreviwer as autopatrolled

### DIFF
--- a/jobs/fastcgi.nomad
+++ b/jobs/fastcgi.nomad
@@ -144,7 +144,7 @@ variable "hotfix" {
  */
 
 $wgMWLoggerDefaultSpi = [ 'class' => 'MediaWiki\\Logger\\LegacySpi' ]; # default
-$wgGroupPermissions['autoreview']['autopatrol'] = true;
+$wgGroupPermissions['autopatrolled']['autopatrol'] = true;
 
 // Maintenance
 // 점검이 끝나면 아래 라인 주석처리한 뒤, 아래 문서 내용을 비우면 됨


### PR DESCRIPTION
### pre-merge

- [ ] The checksums are verified.
- [ ] The `MEDIAWIKI_SKIP_UPDATE` environment variable is set correctly.
