### PR TITLE
Block related permissions

### DIFF
--- a/jobs/fastcgi.nomad
+++ b/jobs/fastcgi.nomad
@@ -145,6 +145,10 @@ variable "hotfix" {
 
 $wgMWLoggerDefaultSpi = [ 'class' => 'MediaWiki\\Logger\\LegacySpi' ]; # default
 $wgGroupPermissions['autopatrolled']['autopatrol'] = true;
+$wgGroupPermissions['blocker']['block'] = true;
+$wgGroupPermissions['blocker']['blockemail'] = true;
+$wgGroupPermissions['blocker']['unblockself'] = true;
+$wgGroupPermissions['user']['torunblocked'] = false;
 
 // Maintenance
 // 점검이 끝나면 아래 라인 주석처리한 뒤, 아래 문서 내용을 비우면 됨


### PR DESCRIPTION
### pre-merge

- [ ] The checksums are verified.
- [ ] The `MEDIAWIKI_SKIP_UPDATE` environment variable is set correctly.
