### PR TITLE
hotfix: Enable blocked external domain

### DIFF
--- a/jobs/fastcgi.nomad
+++ b/jobs/fastcgi.nomad
@@ -250,6 +250,11 @@ $wgScribuntoEngineConf['luasandbox']['cpuLimit'] = 3;
 $wgScribuntoEngineConf['luasandbox']['memoryLimit'] = 52428800; # 50 MiB
 
 $wgMWLoggerDefaultSpi = [ 'class' => 'MediaWiki\\Logger\\LegacySpi' ]; # default
+
+$wgAbuseFilterEnableBlockedExternalDomain = true;
+$wgGroupPermissions['abusefilter']['abusefilter-modify-blocked-external-domains'] = true;
+$wgGroupPermissions['abusefilter']['abusefilter-bypass-blocked-external-domains'] = true;
+
 # https://github.com/femiwiki/UnifiedExtensionForFemiwiki/issues/147
 $wgUnifiedExtensionForFemiwikiBlockByEmail = false;
 


### PR DESCRIPTION
### pre-merge

- [ ] The checksums are verified.
- [ ] The `MEDIAWIKI_SKIP_UPDATE` environment variable is set correctly.
