### PR TITLE
Set BlockTargetMigrationStage

### DIFF
--- a/jobs/fastcgi.nomad
+++ b/jobs/fastcgi.nomad
@@ -246,6 +246,8 @@ variable "hotfix" {
  * @file
  */
 
+$wgBlockTargetMigrationStage = SCHEMA_COMPAT_WRITE_BOTH | SCHEMA_COMPAT_READ_OLD;
+
 $wgScribuntoEngineConf['luasandbox']['cpuLimit'] = 3;
 $wgScribuntoEngineConf['luasandbox']['memoryLimit'] = 52428800; # 50 MiB
 


### PR DESCRIPTION
https://www.mediawiki.org/wiki/Manual:$wgBlockTargetMigrationStage

### pre-merge

- [ ] The checksums are verified.
- [ ] The `MEDIAWIKI_SKIP_UPDATE` environment variable is set correctly.
