### PR TITLE
Typo in fastcgi.nomad

### DIFF
--- a/jobs/fastcgi.nomad
+++ b/jobs/fastcgi.nomad
@@ -276,7 +276,7 @@ $wgGroupPermissions['autoconfirmed']['flow-hide'] = true;
 $wgGroupPermissions['autoconfirmed']['flow-lock'] = true;
 $wgGroupPermissions['autoconfirmed']['editcontentmodel'] = true;
 $wgGroupPermissions['autoconfirmed']['move'] = true;
-$wgGroupPermissions['rollbacker']['rollbacker'] = true;
+$wgGroupPermissions['rollbacker']['rollback'] = true;
 
 $wgBlacklistSettings = [
 	'spam' => [


### PR DESCRIPTION
### pre-merge

- [ ] The checksums are verified.
- [ ] The `MEDIAWIKI_SKIP_UPDATE` environment variable is set correctly.
