### PR TITLE
Disable test nomad cluster

### DIFF
--- a/terraform/base.tf
+++ b/terraform/base.tf
@@ -54,6 +54,5 @@ provider "nomad" {
   address      = data.terraform_remote_state.aws.outputs.test_nomad_addr
   secret_id    = var.test_nomad_token
   consul_token = var.test_consul_token
-  # Should be specified explicitly because of the bug https://github.com/femiwiki/nomad/issues/99
-  region = "global"
+  region       = "global"
 }

--- a/terraform/mediawiki.tf
+++ b/terraform/mediawiki.tf
@@ -23,6 +23,7 @@ resource "nomad_job" "memcached" {
 
 resource "nomad_job" "test_memcached" {
   provider = nomad.test
+  count    = 0
   jobspec  = file("../jobs/memcached.nomad")
   detach   = false
 
@@ -50,6 +51,7 @@ resource "nomad_job" "fastcgi" {
 
 resource "nomad_job" "test_fastcgi" {
   provider = nomad.test
+  count    = 0
   depends_on = [
     nomad_job.memcached,
   ]


### PR DESCRIPTION
It makes the whole terraform runs fail.

### pre-merge

- [ ] The checksums are verified.
- [ ] The `MEDIAWIKI_SKIP_UPDATE` environment variable is set correctly.
