### PR TITLE
docker: Default network mode is not bridge

### DIFF
--- a/jobs/fastcgi.nomad
+++ b/jobs/fastcgi.nomad
@@ -215,7 +215,7 @@ job "fastcgi" {
         ]
 
         cpu_hard_limit = true
-        network_mode   = local.main ? "host" : "bridge"
+        network_mode   = local.main ? "host" : ""
       }
 
       resources {


### PR DESCRIPTION
#280

When emptying it, the service mesh starts to work.

### pre-merge

- [ ] The checksums are verified.
- [ ] The `MEDIAWIKI_SKIP_UPDATE` environment variable is set correctly.
