### PR TITLE
Make fastcgi alloc fail

### DIFF
--- a/jobs/fastcgi.nomad
+++ b/jobs/fastcgi.nomad
@@ -220,6 +220,7 @@ job "fastcgi" {
 
     restart {
       attempts = 0
+      mode     = "fail"
     }
   }
 


### PR DESCRIPTION
### pre-merge

- [ ] The checksums are verified.
- [ ] The `MEDIAWIKI_SKIP_UPDATE` environment variable is set correctly.
