### PR TITLE
Remove constraint

### DIFF
--- a/jobs/fastcgi.nomad
+++ b/jobs/fastcgi.nomad
@@ -1,24 +1,10 @@
-variable "green" {
-  type    = bool
-  default = false
-}
-
 variable "mysql_password_mediawiki" {
   type    = string
   default = ""
 }
 
-locals {
-  blue = !var.green
-}
-
 job "fastcgi" {
   datacenters = ["dc1"]
-
-  constraint {
-    operator = "distinct_hosts"
-    value    = true
-  }
 
   group "fastcgi" {
     count = 3
@@ -225,10 +211,9 @@ job "fastcgi" {
   }
 
   update {
-    auto_revert  = true
-    auto_promote = var.green ? true : false
-    # canary count equal to the desired count allows a Nomad job to model blue/green deployments
-    canary            = var.green ? 1 : 0
+    auto_revert       = true
+    auto_promote      = true
+    canary            = 1
     progress_deadline = "1h"
   }
 }

--- a/terraform/mediawiki.tf
+++ b/terraform/mediawiki.tf
@@ -40,7 +40,6 @@ resource "nomad_job" "fastcgi_green" {
   hcl2 {
     allow_fs = true
     vars = {
-      green                    = true
       mysql_password_mediawiki = var.mysql_password_mediawiki
     }
   }


### PR DESCRIPTION
We have 3 nodes, so setting distinct_hosts and count = 3 is not a
reachable state.

### pre-merge

- [ ] The checksums are verified.
- [ ] The `MEDIAWIKI_SKIP_UPDATE` environment variable is set correctly.
