### PR TITLE
fastcgi: Disable blocking by emals

### DIFF
--- a/jobs/fastcgi.nomad
+++ b/jobs/fastcgi.nomad
@@ -245,6 +245,7 @@ variable "hotfix" {
  */
 
 $wgAutoConfirmAge = 3600;
+$wgUnifiedExtensionForFemiwikiBlockByEmail = false;
 
 // Maintenance
 // 점검이 끝나면 아래 라인 주석처리한 뒤, 아래 문서 내용을 비우면 됨


### PR DESCRIPTION
### pre-merge

- [x] The checksums are verified.
- [x] The `MEDIAWIKI_SKIP_UPDATE` environment variable is set correctly.
