### PR TITLE
Add health check for Caddy

### DIFF
--- a/caddy/Caddyfile
+++ b/caddy/Caddyfile
@@ -16,8 +16,8 @@ femiwiki.com *.femiwiki.com 127.0.0.1:80 localhost:80 {
 	encode gzip
 	mwcache {
 		ristretto {
-			num_counters 20000
-			max_cost 10000
+			num_counters 10000
+			max_cost 1000
 			buffer_items 64
 		}
 		purge_acl {

--- a/caddy/Caddyfile
+++ b/caddy/Caddyfile
@@ -42,6 +42,8 @@ femiwiki.com *.femiwiki.com 127.0.0.1:80 localhost:80 {
 	rewrite /w/api.php /api.php
 	rewrite /w/* /index.php
 
+	respond /health-check 200
+
 	# Ignore malformed requests
 	@filter0 {
 		path /w/특수:내언어/페미위키:대문

--- a/jobs/http.nomad
+++ b/jobs/http.nomad
@@ -14,7 +14,7 @@ job "http" {
         source      = "https://github.com/femiwiki/nomad/raw/main/caddy/Caddyfile"
         destination = "local/Caddyfile.tpl"
         mode        = "file"
-        options { checksum = "md5:3898f8a9e8b3e1e2190ee4d62146b9a7" }
+        options { checksum = "md5:ccf8e4159b5a7d532b4f5233391562a9" }
       }
       template {
         source      = "local/Caddyfile.tpl"
@@ -90,6 +90,15 @@ job "http" {
     service {
       name = "http"
       port = "80"
+
+      check {
+        type     = "script"
+        task     = "http"
+        command  = "curl"
+        args     = ["127.0.0.1/health-check"]
+        interval = "5s"
+        timeout  = "2s"
+      }
 
       connect {
         sidecar_service {


### PR DESCRIPTION
I use a script check because the next check did not work.
```hcl
      check {
        type     = "http"
        path     = "/health-check"
        expose   = true
        interval = "5s"
        timeout  = "2s"

        check_restart {
          limit = 0
        }
      }
```

### pre-merge

- [x] The checksums are verified.
- [ ] The `MEDIAWIKI_SKIP_UPDATE` environment variable is set correctly.
