### PR TITLE
http: Set AWS_REGION

### DIFF
--- a/jobs/http.nomad
+++ b/jobs/http.nomad
@@ -67,6 +67,7 @@ job "http" {
 
       env {
         FASTCGI_ADDR        = NOMAD_UPSTREAM_ADDR_fastcgi
+        AWS_REGION          = "ap-northeast-1"
         S3_USE_IAM_PROVIDER = true
         S3_HOST             = "s3.ap-northeast-1.amazonaws.com"
         S3_BUCKET           = "femiwiki-secrets"


### PR DESCRIPTION
Maybe because of a bug, TLS renew failed.

Log:
```json
{
  "level": "error",
  "ts": 1744031984.522659,
  "logger": "tls.renew",
  "msg": "could not get certificate from issuer",
  "identifier": "femiwiki.com",
  "issuer": "acme-v02.api.letsencrypt.org-directory",
  "error": "[femiwiki.com] solving challenges: presenting for challenge: adding temporary record for zone \"femiwiki.com.\": operation error Route 53: ListHostedZonesByName, failed to resolve service endpoint, endpoint rule error, Invalid Configuration: Missing Region (order=https://acme-v02.api.letsencrypt.org/acme/order/107891528/371690862897) (ca=https://acme-v02.api.letsencrypt.org/directory)"
}
```

### pre-merge

- [ ] The checksums are verified.
- [ ] The `MEDIAWIKI_SKIP_UPDATE` environment variable is set correctly.
